### PR TITLE
cross rust in go

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,9 +34,7 @@ build:deploy --extra_toolchains=@llvm_toolchain_with_sysroot//:cc-toolchain-x86_
 # https://github.com/grailbio/bazel-toolchain/pull/229.
 build:deploy --features=-libtool
 build:deploy --features=fully_static_link
-build:deploy --platforms=@rules_go//go/toolchain:linux_amd64,@toolchains_llvm//platforms:linux-x86_64
-build:deploy --@rules_go//go/config:pure=false
-build:deploy --@rules_go//go/config:static=true
+build:deploy --platforms=@toolchains_llvm//platforms:linux-x86_64
 
 test --build_tests_only
 test --incompatible_exclusive_test_sandboxed

--- a/.bazelrc
+++ b/.bazelrc
@@ -34,7 +34,9 @@ build:deploy --extra_toolchains=@llvm_toolchain_with_sysroot//:cc-toolchain-x86_
 # https://github.com/grailbio/bazel-toolchain/pull/229.
 build:deploy --features=-libtool
 build:deploy --features=fully_static_link
-build:deploy --platforms=@rules_go//go/toolchain:linux_amd64
+build:deploy --platforms=@rules_go//go/toolchain:linux_amd64,@toolchains_llvm//platforms:linux-x86_64
+build:deploy --@rules_go//go/config:pure=false
+build:deploy --@rules_go//go/config:static=true
 
 test --build_tests_only
 test --incompatible_exclusive_test_sandboxed

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -46,7 +46,15 @@ http_archive(
 )
 load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains", "rust_repository_set")
 rules_rust_dependencies()
-rust_register_toolchains(edition = "2021", versions = ["1.76.0"])
+RUST_VERSION = "1.76.0"
+rust_register_toolchains(edition = "2021", versions = [RUST_VERSION])
+rust_repository_set(
+  name = "rust_x86_64_unknown_musl",
+  edition = "2021",
+  exec_triple = "aarch64-apple-darwin",
+  extra_target_triples = ["x86_64-unknown-linux-musl"],
+  versions = [RUST_VERSION],
+)
 load("@rules_rust//crate_universe:defs.bzl", "crate", "crates_repository", "render_config")
 crates_repository(
   name = "crates",

--- a/rust_in_go/BUILD.bazel
+++ b/rust_in_go/BUILD.bazel
@@ -12,7 +12,7 @@ rust_static_library(
 
 go_library(
     name = "rust_in_go_lib",
-    srcs = ["main.go", "lib.h"],
+    srcs = ["main.go"],
     cdeps = [":lib"],
     cgo = True,
     importpath = "github.com/sunb26/xat/rust_in_go",

--- a/rust_in_go/BUILD.bazel
+++ b/rust_in_go/BUILD.bazel
@@ -22,5 +22,6 @@ go_library(
 go_binary(
     name = "rust_in_go",
     embed = [":rust_in_go_lib"],
+    pure = "off",
     visibility = ["//visibility:public"],
 )

--- a/rust_in_go/lib.h
+++ b/rust_in_go/lib.h
@@ -1,1 +1,0 @@
-char *hello_message();

--- a/rust_in_go/main.go
+++ b/rust_in_go/main.go
@@ -1,13 +1,12 @@
 package main
 
-/*
-#cgo LDFLAGS: ./liblib.a
-#include "./lib.h"
-*/
-import "C"
-
-import "fmt"
+import (
+	// char *hello_message();
+	"C"
+	"fmt"
+)
 
 func main() {
 	fmt.Println(C.GoString(C.hello_message()))
+	// fmt.Println("Hello, world!")
 }


### PR DESCRIPTION
## initially failed to cross-compile rust-in-go

* not fully supported by rules_go https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/cross_compilation.md
* still keep the changes and submit this PR as they are relevant for downstream changes
* one potential solution is to deploy to fly.io in CI actions, however this would risk sensitive secrets even if they correctly configured as github action secrets
* select solution is to compile rust program in web_assembly https://bazelbuild.github.io/rules_rust/rust_wasm_bindgen.html and https://github.com/huggingface/candle/blob/0c5eecbc0faa7e642210800c735ad8137d5a9e08/candle-wasm-examples/blip/README.md, then use a WASM runtime in golang to load and run the bundle on the server
  * this also prepares for WASM binary to be run in the browser in the future

## successfully cross-compile rust-in-go

* turn off pure at the target, since setting purity in bazelrc was ineffective prior
* doing so caused the go compilation to rely on cc toolchain resolution
* the toolchain resolution is determined by llvm_toolchain
* both the rust and go binaries use the same toolchain in this case
* crucially, the cross-compiled binary is statically linked so it can be deployed in a docker container without a base image

```bash
~/Projects/xat> file bazel-bin/rust_in_go/rust_in_go_/rust_in_go                               2024-03-10 01:42:08 AM AM
bazel-bin/rust_in_go/rust_in_go_/rust_in_go: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, for GNU/Linux 2.6.32, Go BuildID=redacted, BuildID[md5/uuid]=8d90723e74a98694cd1d405df8457076, with debug_info, not stripped
```

## debug log

the persistent error is the file rust_in_go/main.go was not recognized as the main package


```bash
~/Projects/xat> aspect build //rust_in_go --config=deploy                                      2024-03-10 01:08:01 AM AM
INFO: Invocation ID: 5986f8ba-e731-46d1-9bf1-4c41c0763158
WARNING: Build option --@@rules_go~//go/config:pure has changed, discarding analysis cache (this can be expensive, see https://bazel.build/advanced/performance/iteration-speed).
INFO: Analyzed target //rust_in_go:rust_in_go (1 packages loaded, 26953 targets configured).
ERROR: /Users/lev1ty/Projects/xat/rust_in_go/BUILD.bazel:22:10: GoLink rust_in_go/rust_in_go_/rust_in_go failed: (Exit 1): builder failed: error executing GoLink command (from target //rust_in_go:rust_in_go) bazel-out/darwin_arm64-opt-exec-ST-13d3ddad9198/bin/external/rules_go~~go_sdk~main___download_0/builder_reset/builder link -sdk external/rules_go~~go_sdk~main___download_0 -installsuffix linux_amd64 ... (remaining 14 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
external/rules_go~~go_sdk~main___download_0/pkg/tool/darwin_arm64/link: bazel-out/darwin_arm64-opt/bin/rust_in_go/rust_in_go.a: not package main
link: error running subcommand GOPATH= \
GOROOT_FINAL=GOROOT \
GOROOT=bazel-out/darwin_arm64-opt-ST-00721b0c0d4a/bin/external/rules_go~/stdlib_ \
GOEXPERIMENT=nocoverageredesign \
GOTOOLCHAIN=local \
TMPDIR=/var/folders/v3/2hx20m294q96m8mb6h1lzw240000gn/T/ \
CGO_ENABLED=0 \
GOOS=linux \
GOARCH=amd64 \
__CF_USER_TEXT_ENCODING=0x1F5:0x0:0x52 \
external/rules_go~~go_sdk~main___download_0/pkg/tool/darwin_arm64/link -importcfg bazel-out/darwin_arm64-opt/bin/rust_in_go/rust_in_go_/importcfg272225248 -o bazel-out/darwin_arm64-opt/bin/rust_in_go/rust_in_go_/rust_in_go -linkmode internal -buildid=redacted -extldflags -static /private/var/tmp/_bazel_lev1ty/3b8fb8eaf07df7eb5946fd70f125660d/sandbox/darwin-sandbox/1361/execroot/_main/bazel-out/darwin_arm64-opt/bin/rust_in_go/rust_in_go.a: exit status 2
INFO: Found 1 target...
Target //rust_in_go:rust_in_go failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 1.711s, Critical Path: 1.16s
INFO: 6 processes: 2 disk cache hit, 4 internal.
ERROR: Build did NOT complete successfully
Error: bazel exited with exit code: 1
```

this only happens if `import "C"` is included and can be verified that no `main` strings are in the c-archive

```shell
~/Projects/xat> strings bazel-bin/rust_in_go/rust_in_go.a                                      2024-03-10 01:16:57 AM AM
go object linux amd64 go1.22.1 GOAMD64=v1 X:regabiwrappers,regabiargs,allocheaders,exectracer2
go120ld*
go:cuinfo.producer.maingo:cuinfo.packagename.mainmain..inittask<autogenerated>
regabiempty
```

if we comment out `import "C"` and dependent lines of code, then the c-archive contains `main`; and the cross-compile succeeds

```shell
~/Projects/xat> strings bazel-bin/rust_in_go/rust_in_go.a                                      2024-03-10 01:18:37 AM AM
go object linux amd64 go1.22.1 GOAMD64=v1 X:regabiwrappers,regabiargs,allocheaders,exectracer2
main
go120ld
fmtosiomain.maintype:*os.Filemain..stmp_0os.Stdoutgo:itab.*os.File,io.Writerfmt.Fprintlngclocals
g2BeySu+wFnoycgXfElmcg==gclocals
EaPwxsZ75yY1hHMVZLmk6g==main.main.stkobjrust_in_go/main.go$GOROOT/src/fmt/print.gofmt.Printlntype:[1]interface {}go:info.fmt.Println$abstractgo:cuinfo.producer.maingo:cuinfo.packagename.maintype:[]interface {}type:intgo:info.[]interface {}go:info.intgo:info.errortype:io.Writeros.(*File).Writemain..inittaskfmt..inittaskgo:string."Hello, world!"runtime.nilinterequal
fruntime.memequal64
fruntime.gcbits.0100000000000000type:.namedata.*[1]interface {}-type:*[1]interface {}runtime.gcbits.0200000000000000type:interface {}<autogenerated>$GOROOT/src/io/io.go$GOROOT/src/os/types.go$GOROOT/src/os/file_unix.go$GOROOT/src/internal/poll/fd_unix.go$GOROOT/src/internal/poll/fd_mutex.go$GOROOT/src/internal/poll/fd_unixjs.go$GOROOT/src/syscall/ztypes_linux_amd64.go$GOROOT/src/syscall/syscall_linux_amd64.go$GOROOT/src/internal/poll/fd_poll_runtime.go$GOROOT/src/internal/poll/fd_fsync_posix.go$GOROOT/src/time/time.go$GOROOT/src/time/zoneinfo.go$GOROOT/src/time/format.go$GOROOT/src/time/format_rfc3339.go$GOROOT/src/internal/poll/fd_posix.go$GOROOT/src/syscall/syscall_unix.go$GOROOT/src/syscall/syscall_linux.go$GOROOT/src/syscall/syscall.go$GOROOT/src/internal/poll/sockopt.go$GOROOT/src/internal/poll/sockopt_linux.go$GOROOT/src/internal/poll/sockopt_unix.go$GOROOT/src/internal/poll/sockoptip.go$GOROOT/src/internal/poll/writev.go$GOROOT/src/os/dir_unix.go$GOROOT/src/os/dir.go$GOROOT/src/io/fs/fs.go$GOROOT/src/os/file.go$GOROOT/src/syscall/net.go$GOROOT/src/os/file_posix.go$GOROOT/src/os/stat_unix.go$GOROOT/src/os/zero_copy_linux.go
^mz{m
)i3|XV
JMV 1X
ywC8[
*Uq&Q
vLUH
|$(H
T$(H
T$0H
main.main
Hello, world!
*[1]interface {}
regabimain
fmt.Println
n j=
```