### PR TITLE
add receipt + snapshot tables

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -1,8 +1,8 @@
 # @generated
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
-.npmrc=-592547263
-pnpm-lock.yaml=980206083
-package.json=-1129916005
-pnpm-workspace.yaml=-589074682
-web/package.json=-1701499812
+.npmrc=-1189095866
+pnpm-lock.yaml=336520786
+package.json=-704207577
+pnpm-workspace.yaml=-940666316
+web/package.json=-762753479

--- a/atlas/schema.hcl
+++ b/atlas/schema.hcl
@@ -19,7 +19,7 @@ table "receipt_snapshot_v1" {
     type = bigint
     comment = "If scan_id is null, this means the snapshot is a result of manual alterations to the entry. If it is not null, that means this snapshot is based on the inference result of an image scan."
   }
-  column "tax" {
+  column "tax_gst_hst" {
     null = false
     type = money
     comment = "The GST/HST amount listed on the receipt."


### PR DESCRIPTION
Store snapshots of receipts. The receipt data includes overview amounts such as total HST/GST, gratuities, etc. The expense table should be the breakdown of expenses that make up the subtotal.

Subtotal and Total are not stored because they can be calculated.